### PR TITLE
GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Build
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build packages
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            TARGET: macos
+            CMD_BUILD: >
+              pyinstaller -F -w -n metryczka metryczka.py &&
+              cd dist/ &&
+              zip -r9 metryczka metryczka.app/
+            OUT_FILE_NAME: metryczka.zip
+            ASSET_MIME: application/zip
+
+          - os: windows-latest
+            TARGET: windows
+            CMD_BUILD: pyinstaller -F -w -n metryczka metryczka.py
+            OUT_FILE_NAME: metryczka.exe
+            ASSET_MIME: application/vnd.microsoft.portable-executable
+
+          - os: ubuntu-latest
+            TARGET: linux
+            CMD_BUILD: >
+              pyinstaller -F -w -n metryczka metryczka.py &&
+              cd dist/ &&
+              tar -czvf metryczka.tar.gz metryczka
+            OUT_FILE_NAME: metryczka.tar.gz
+            ASSET_MIME: application/gzip
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+          pip install -r requirements.txt
+
+      - name: Build with pyinstaller for ${{ matrix.TARGET }}
+        run: ${{ matrix.CMD_BUILD }}
+
+      - name: Upload binaries to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ./dist/${{ matrix.OUT_FILE_NAME }}
+          name: Release ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Propozycja uproszczenia budowania paczek za pomocą GitHub Actions. 
Wystarczy otagować commita np.
`git tag -a v1.3 -m "version 1.3"`
następnie wysłać na repo komendą:
`git push origin v1.3`

GitHub powinien automatycznie wygenerować paczki na trzy systemy. 